### PR TITLE
Pnb

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # CANMIOfirmware
 PIC firmware for CANMIO with configurable IO. Uses the CBUSlib https://github.com/MERG-DEV/CBUSlib.
 
+
 Currently work in progress.
 ToDos and DONEs:
 TODOs
@@ -16,7 +17,7 @@ TODOs
   * Heartbeat message
   * Fix INVERTED for all types
   * Randomise bounce
-  * RFID input
+  * RFID input - PNB now taken on this task - branch PNB
   * Analogue inputs for magnetic and current sense detectors 
 
 DONES:

--- a/canmio.h
+++ b/canmio.h
@@ -57,6 +57,7 @@ extern "C" {
  */
 // Number of IO pins
 #define NUM_IO 16
+#define NUM_IO_MAIN 8  // pins on the main board
 // look in mioNv as the IO pin config is stored in NVs
     
 /*******************************************************************
@@ -67,10 +68,17 @@ extern "C" {
 #define BETA        3
 
 #include "GenericTypeDefs.h"
-#include "cbusdefs8q.h"
+#include "cbusdefs8r.h"
 
 #define MANU_ID         MANU_MERG
+    
+#ifdef CANBIP
+#define MODULE_ID       MTYP_CANBIP
+#define MODULE_TYPE     "BIP    "       // MUST be at least 7 character long. First 7 are used    
+#else
 #define MODULE_ID       MTYP_CANMIO
+#endif
+    
 #define MODULE_TYPE     "MIO    "       // MUST be at least 7 character long. First 7 are used.
 #define MODULE_FLAGS    PF_COMBI+PF_BOOT+PF_COE  // Producer, consumer, boot
 #define BUS_TYPE        PB_CAN

--- a/main.c
+++ b/main.c
@@ -148,9 +148,16 @@ void ISRLow(void);
 void ISRHigh(void);
 #endif
 
-// Default type is INPUT
-#ifndef TYPE_DEFAULT
-#define TYPE_DEFAULT    TYPE_INPUT
+// Default type is INPUT for all on CANMIO, 
+// on the CANBIP it is OUTPUT for the main board and INPUT for the expansion (daughterboard) connections)
+#ifndef TYPE_DEFAULT_MAIN
+#ifdef CANBIP
+#define TYPE_DEFAULT_MAIN   TYPE_OUTPUT
+#else
+#define TYPE_DEFAULT_MAIN   TYPE_INPUT
+#endif
+
+#define TYPE_DEFAULT_EXP    TYPE_INPUT
 #endif
 
 // PIN configs
@@ -411,7 +418,7 @@ void factoryResetFlash(void) {
     clearAllEvents();
     // perform other actions based upon type
     for (io=0; io<NUM_IO; io++) {
-        setType(io, TYPE_DEFAULT);
+        setType(io, (io < NUM_IO_MAIN) ? TYPE_DEFAULT_MAIN : TYPE_DEFAULT_EXP);
     } 
     flushFlashImage();
 }


### PR DESCRIPTION
Minor changes to support a version that builds for CANBIP.  The only differences are the conditional compilation that creates the defaults as 8 outputs and 8 inputs when building for CANBIP and identifies to FCU as a CANBIP.